### PR TITLE
Fixed imgur album regex

### DIFF
--- a/mediator.js
+++ b/mediator.js
@@ -74,7 +74,7 @@
 			return ReplaceImage(url, elem, $elem);
 
 		if (urlo.host == 'imgur.com' || urlo.host == 'www.imgur.com') {
-			var match = urlo.path.match(/\/a\/([\w]{5,7})(\/.*)?$/);
+			var match = urlo.path.match(/\/a\/([\w]{5,7})/);
 			if (match) return ReplaceImgurGal(match[1], elem, $elem);
 
 			var match = urlo.path.match(/([\w]{5,7})$/);


### PR DESCRIPTION
Imgur album regex now handles cases where the user pastes an album link
with trailing information (often found if they have been viewing the
gallery and copy the address bar contents).

Example: http://imgur.com/a/XjHv1/embed#0

Previously this would fail (and cause Mediator to display an Imgur "image no longer available" graphic), as the regex could not match albums with additional data after the album ID.
