### PR TITLE
Fixed dynamic replacement when posting comments

### DIFF
--- a/mediator.js
+++ b/mediator.js
@@ -51,7 +51,7 @@
 
 		$('.Message a').each(Check);
 		$('.MessageList').live('DOMNodeInserted', function(e) {
-			if ($(e.target).hasClass('Comment')) {
+			if ($(e.target).hasClass('Item')) {
 				$('div.Message a', e.target).each(Check);
 			}
 		});


### PR DESCRIPTION
Mediator wasn't doing anything when posting new comments; turns out, it was addressing the wrong element in the event handler. This Fixes All The Things.